### PR TITLE
calling FirstOrDefault solves the problem of type names as a string

### DIFF
--- a/src/ESIClient.Dotcore/Api/AllianceApi.cs
+++ b/src/ESIClient.Dotcore/Api/AllianceApi.cs
@@ -435,7 +435,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -503,7 +503,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -576,7 +576,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetAlliancesAllianceIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetAlliancesAllianceIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetAlliancesAllianceIdOk)));
         }
 
@@ -650,7 +650,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetAlliancesAllianceIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetAlliancesAllianceIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetAlliancesAllianceIdOk)));
         }
 
@@ -723,7 +723,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -797,7 +797,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -870,7 +870,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetAlliancesAllianceIdIconsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetAlliancesAllianceIdIconsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetAlliancesAllianceIdIconsOk)));
         }
 
@@ -944,7 +944,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetAlliancesAllianceIdIconsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetAlliancesAllianceIdIconsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetAlliancesAllianceIdIconsOk)));
         }
 
@@ -1017,7 +1017,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetAlliancesNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetAlliancesNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetAlliancesNames200Ok>)));
         }
 
@@ -1091,7 +1091,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetAlliancesNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetAlliancesNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetAlliancesNames200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/AssetsApi.cs
+++ b/src/ESIClient.Dotcore/Api/AssetsApi.cs
@@ -539,7 +539,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdAssets200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdAssets200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdAssets200Ok>)));
         }
 
@@ -625,7 +625,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdAssets200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdAssets200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdAssets200Ok>)));
         }
 
@@ -710,7 +710,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdAssets200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdAssets200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdAssets200Ok>)));
         }
 
@@ -796,7 +796,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdAssets200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdAssets200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdAssets200Ok>)));
         }
 
@@ -888,7 +888,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostCharactersCharacterIdAssetsLocations200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostCharactersCharacterIdAssetsLocations200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostCharactersCharacterIdAssetsLocations200Ok>)));
         }
 
@@ -981,7 +981,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostCharactersCharacterIdAssetsLocations200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostCharactersCharacterIdAssetsLocations200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostCharactersCharacterIdAssetsLocations200Ok>)));
         }
 
@@ -1073,7 +1073,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostCharactersCharacterIdAssetsNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostCharactersCharacterIdAssetsNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostCharactersCharacterIdAssetsNames200Ok>)));
         }
 
@@ -1166,7 +1166,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostCharactersCharacterIdAssetsNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostCharactersCharacterIdAssetsNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostCharactersCharacterIdAssetsNames200Ok>)));
         }
 
@@ -1258,7 +1258,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostCorporationsCorporationIdAssetsLocations200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostCorporationsCorporationIdAssetsLocations200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostCorporationsCorporationIdAssetsLocations200Ok>)));
         }
 
@@ -1351,7 +1351,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostCorporationsCorporationIdAssetsLocations200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostCorporationsCorporationIdAssetsLocations200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostCorporationsCorporationIdAssetsLocations200Ok>)));
         }
 
@@ -1443,7 +1443,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostCorporationsCorporationIdAssetsNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostCorporationsCorporationIdAssetsNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostCorporationsCorporationIdAssetsNames200Ok>)));
         }
 
@@ -1536,7 +1536,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostCorporationsCorporationIdAssetsNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostCorporationsCorporationIdAssetsNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostCorporationsCorporationIdAssetsNames200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/BookmarksApi.cs
+++ b/src/ESIClient.Dotcore/Api/BookmarksApi.cs
@@ -439,7 +439,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdBookmarks200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdBookmarks200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdBookmarks200Ok>)));
         }
 
@@ -525,7 +525,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdBookmarks200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdBookmarks200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdBookmarks200Ok>)));
         }
 
@@ -610,7 +610,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdBookmarksFolders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdBookmarksFolders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdBookmarksFolders200Ok>)));
         }
 
@@ -696,7 +696,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdBookmarksFolders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdBookmarksFolders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdBookmarksFolders200Ok>)));
         }
 
@@ -781,7 +781,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdBookmarks200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdBookmarks200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdBookmarks200Ok>)));
         }
 
@@ -867,7 +867,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdBookmarks200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdBookmarks200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdBookmarks200Ok>)));
         }
 
@@ -952,7 +952,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdBookmarksFolders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdBookmarksFolders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdBookmarksFolders200Ok>)));
         }
 
@@ -1038,7 +1038,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdBookmarksFolders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdBookmarksFolders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdBookmarksFolders200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/CalendarApi.cs
+++ b/src/ESIClient.Dotcore/Api/CalendarApi.cs
@@ -439,7 +439,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdCalendar200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdCalendar200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdCalendar200Ok>)));
         }
 
@@ -525,7 +525,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdCalendar200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdCalendar200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdCalendar200Ok>)));
         }
 
@@ -613,7 +613,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdCalendarEventIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdCalendarEventIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdCalendarEventIdOk)));
         }
 
@@ -702,7 +702,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdCalendarEventIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdCalendarEventIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdCalendarEventIdOk)));
         }
 
@@ -790,7 +790,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdCalendarEventIdAttendees200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdCalendarEventIdAttendees200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdCalendarEventIdAttendees200Ok>)));
         }
 
@@ -879,7 +879,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdCalendarEventIdAttendees200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdCalendarEventIdAttendees200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdCalendarEventIdAttendees200Ok>)));
         }
 
@@ -976,7 +976,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -1074,7 +1074,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 

--- a/src/ESIClient.Dotcore/Api/CharacterApi.cs
+++ b/src/ESIClient.Dotcore/Api/CharacterApi.cs
@@ -1043,7 +1043,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdOk)));
         }
 
@@ -1117,7 +1117,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdOk)));
         }
 
@@ -1199,7 +1199,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdAgentsResearch200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdAgentsResearch200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdAgentsResearch200Ok>)));
         }
 
@@ -1282,7 +1282,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdAgentsResearch200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdAgentsResearch200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdAgentsResearch200Ok>)));
         }
 
@@ -1367,7 +1367,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdBlueprints200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdBlueprints200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdBlueprints200Ok>)));
         }
 
@@ -1453,7 +1453,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdBlueprints200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdBlueprints200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdBlueprints200Ok>)));
         }
 
@@ -1526,7 +1526,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdCorporationhistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdCorporationhistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdCorporationhistory200Ok>)));
         }
 
@@ -1600,7 +1600,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdCorporationhistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdCorporationhistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdCorporationhistory200Ok>)));
         }
 
@@ -1682,7 +1682,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdFatigueOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdFatigueOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdFatigueOk)));
         }
 
@@ -1765,7 +1765,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdFatigueOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdFatigueOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdFatigueOk)));
         }
 
@@ -1847,7 +1847,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdMedals200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdMedals200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdMedals200Ok>)));
         }
 
@@ -1930,7 +1930,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdMedals200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdMedals200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdMedals200Ok>)));
         }
 
@@ -2012,7 +2012,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdNotifications200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdNotifications200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdNotifications200Ok>)));
         }
 
@@ -2095,7 +2095,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdNotifications200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdNotifications200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdNotifications200Ok>)));
         }
 
@@ -2177,7 +2177,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdNotificationsContacts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdNotificationsContacts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdNotificationsContacts200Ok>)));
         }
 
@@ -2260,7 +2260,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdNotificationsContacts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdNotificationsContacts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdNotificationsContacts200Ok>)));
         }
 
@@ -2333,7 +2333,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdPortraitOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdPortraitOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdPortraitOk)));
         }
 
@@ -2407,7 +2407,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdPortraitOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdPortraitOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdPortraitOk)));
         }
 
@@ -2489,7 +2489,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdRolesOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdRolesOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdRolesOk)));
         }
 
@@ -2572,7 +2572,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdRolesOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdRolesOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdRolesOk)));
         }
 
@@ -2654,7 +2654,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdStandings200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdStandings200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdStandings200Ok>)));
         }
 
@@ -2737,7 +2737,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdStandings200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdStandings200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdStandings200Ok>)));
         }
 
@@ -2819,7 +2819,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdStats200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdStats200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdStats200Ok>)));
         }
 
@@ -2902,7 +2902,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdStats200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdStats200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdStats200Ok>)));
         }
 
@@ -2984,7 +2984,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdTitles200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdTitles200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdTitles200Ok>)));
         }
 
@@ -3067,7 +3067,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdTitles200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdTitles200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdTitles200Ok>)));
         }
 
@@ -3140,7 +3140,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersNames200Ok>)));
         }
 
@@ -3214,7 +3214,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersNames200Ok>)));
         }
 
@@ -3294,7 +3294,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostCharactersAffiliation200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostCharactersAffiliation200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostCharactersAffiliation200Ok>)));
         }
 
@@ -3375,7 +3375,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostCharactersAffiliation200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostCharactersAffiliation200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostCharactersAffiliation200Ok>)));
         }
 
@@ -3467,7 +3467,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<float?>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (float?) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(float?)));
         }
 
@@ -3560,7 +3560,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<float?>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (float?) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(float?)));
         }
 

--- a/src/ESIClient.Dotcore/Api/ClonesApi.cs
+++ b/src/ESIClient.Dotcore/Api/ClonesApi.cs
@@ -312,7 +312,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdClonesOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdClonesOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdClonesOk)));
         }
 
@@ -395,7 +395,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdClonesOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdClonesOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdClonesOk)));
         }
 
@@ -477,7 +477,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -560,7 +560,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/ContactsApi.cs
+++ b/src/ESIClient.Dotcore/Api/ContactsApi.cs
@@ -728,7 +728,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -813,7 +813,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -898,7 +898,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetAlliancesAllianceIdContacts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetAlliancesAllianceIdContacts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetAlliancesAllianceIdContacts200Ok>)));
         }
 
@@ -984,7 +984,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetAlliancesAllianceIdContacts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetAlliancesAllianceIdContacts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetAlliancesAllianceIdContacts200Ok>)));
         }
 
@@ -1066,7 +1066,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetAlliancesAllianceIdContactsLabels200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetAlliancesAllianceIdContactsLabels200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetAlliancesAllianceIdContactsLabels200Ok>)));
         }
 
@@ -1149,7 +1149,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetAlliancesAllianceIdContactsLabels200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetAlliancesAllianceIdContactsLabels200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetAlliancesAllianceIdContactsLabels200Ok>)));
         }
 
@@ -1234,7 +1234,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdContacts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdContacts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdContacts200Ok>)));
         }
 
@@ -1320,7 +1320,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdContacts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdContacts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdContacts200Ok>)));
         }
 
@@ -1402,7 +1402,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdContactsLabels200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdContactsLabels200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdContactsLabels200Ok>)));
         }
 
@@ -1485,7 +1485,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdContactsLabels200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdContactsLabels200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdContactsLabels200Ok>)));
         }
 
@@ -1570,7 +1570,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContacts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContacts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContacts200Ok>)));
         }
 
@@ -1656,7 +1656,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContacts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContacts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContacts200Ok>)));
         }
 
@@ -1738,7 +1738,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContactsLabels200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContactsLabels200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContactsLabels200Ok>)));
         }
 
@@ -1821,7 +1821,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContactsLabels200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContactsLabels200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContactsLabels200Ok>)));
         }
 
@@ -1925,7 +1925,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -2030,7 +2030,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -2133,7 +2133,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -2237,7 +2237,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 

--- a/src/ESIClient.Dotcore/Api/ContractsApi.cs
+++ b/src/ESIClient.Dotcore/Api/ContractsApi.cs
@@ -559,7 +559,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdContracts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdContracts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdContracts200Ok>)));
         }
 
@@ -645,7 +645,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdContracts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdContracts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdContracts200Ok>)));
         }
 
@@ -733,7 +733,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdContractsContractIdBids200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdContractsContractIdBids200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdContractsContractIdBids200Ok>)));
         }
 
@@ -822,7 +822,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdContractsContractIdBids200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdContractsContractIdBids200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdContractsContractIdBids200Ok>)));
         }
 
@@ -910,7 +910,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdContractsContractIdItems200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdContractsContractIdItems200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdContractsContractIdItems200Ok>)));
         }
 
@@ -999,7 +999,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdContractsContractIdItems200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdContractsContractIdItems200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdContractsContractIdItems200Ok>)));
         }
 
@@ -1084,7 +1084,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContracts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContracts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContracts200Ok>)));
         }
 
@@ -1170,7 +1170,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContracts200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContracts200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContracts200Ok>)));
         }
 
@@ -1261,7 +1261,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContractsContractIdBids200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContractsContractIdBids200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContractsContractIdBids200Ok>)));
         }
 
@@ -1353,7 +1353,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContractsContractIdBids200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContractsContractIdBids200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContractsContractIdBids200Ok>)));
         }
 
@@ -1441,7 +1441,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContractsContractIdItems200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContractsContractIdItems200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContractsContractIdItems200Ok>)));
         }
 
@@ -1530,7 +1530,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContractsContractIdItems200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContractsContractIdItems200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContractsContractIdItems200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/CorporationApi.cs
+++ b/src/ESIClient.Dotcore/Api/CorporationApi.cs
@@ -1581,7 +1581,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdOk)));
         }
 
@@ -1655,7 +1655,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdOk)));
         }
 
@@ -1728,7 +1728,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdAlliancehistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdAlliancehistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdAlliancehistory200Ok>)));
         }
 
@@ -1802,7 +1802,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdAlliancehistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdAlliancehistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdAlliancehistory200Ok>)));
         }
 
@@ -1887,7 +1887,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdBlueprints200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdBlueprints200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdBlueprints200Ok>)));
         }
 
@@ -1973,7 +1973,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdBlueprints200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdBlueprints200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdBlueprints200Ok>)));
         }
 
@@ -2058,7 +2058,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContainersLogs200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContainersLogs200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContainersLogs200Ok>)));
         }
 
@@ -2144,7 +2144,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdContainersLogs200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdContainersLogs200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdContainersLogs200Ok>)));
         }
 
@@ -2226,7 +2226,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdDivisionsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdDivisionsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdDivisionsOk)));
         }
 
@@ -2309,7 +2309,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdDivisionsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdDivisionsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdDivisionsOk)));
         }
 
@@ -2391,7 +2391,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdFacilities200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdFacilities200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdFacilities200Ok>)));
         }
 
@@ -2474,7 +2474,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdFacilities200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdFacilities200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdFacilities200Ok>)));
         }
 
@@ -2547,7 +2547,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdIconsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdIconsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdIconsOk)));
         }
 
@@ -2621,7 +2621,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdIconsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdIconsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdIconsOk)));
         }
 
@@ -2706,7 +2706,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdMedals200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdMedals200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdMedals200Ok>)));
         }
 
@@ -2792,7 +2792,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdMedals200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdMedals200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdMedals200Ok>)));
         }
 
@@ -2877,7 +2877,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdMedalsIssued200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdMedalsIssued200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdMedalsIssued200Ok>)));
         }
 
@@ -2963,7 +2963,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdMedalsIssued200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdMedalsIssued200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdMedalsIssued200Ok>)));
         }
 
@@ -3045,7 +3045,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -3128,7 +3128,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -3210,7 +3210,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<int?>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (int?) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(int?)));
         }
 
@@ -3293,7 +3293,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<int?>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (int?) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(int?)));
         }
 
@@ -3375,7 +3375,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdMembersTitles200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdMembersTitles200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdMembersTitles200Ok>)));
         }
 
@@ -3458,7 +3458,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdMembersTitles200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdMembersTitles200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdMembersTitles200Ok>)));
         }
 
@@ -3540,7 +3540,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdMembertracking200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdMembertracking200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdMembertracking200Ok>)));
         }
 
@@ -3623,7 +3623,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdMembertracking200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdMembertracking200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdMembertracking200Ok>)));
         }
 
@@ -3708,7 +3708,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -3794,7 +3794,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -3882,7 +3882,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdOutpostsOutpostIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdOutpostsOutpostIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdOutpostsOutpostIdOk)));
         }
 
@@ -3971,7 +3971,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdOutpostsOutpostIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdOutpostsOutpostIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdOutpostsOutpostIdOk)));
         }
 
@@ -4053,7 +4053,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdRoles200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdRoles200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdRoles200Ok>)));
         }
 
@@ -4136,7 +4136,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdRoles200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdRoles200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdRoles200Ok>)));
         }
 
@@ -4221,7 +4221,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdRolesHistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdRolesHistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdRolesHistory200Ok>)));
         }
 
@@ -4307,7 +4307,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdRolesHistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdRolesHistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdRolesHistory200Ok>)));
         }
 
@@ -4392,7 +4392,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdShareholders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdShareholders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdShareholders200Ok>)));
         }
 
@@ -4478,7 +4478,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdShareholders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdShareholders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdShareholders200Ok>)));
         }
 
@@ -4563,7 +4563,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdStandings200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdStandings200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdStandings200Ok>)));
         }
 
@@ -4649,7 +4649,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdStandings200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdStandings200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdStandings200Ok>)));
         }
 
@@ -4734,7 +4734,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdStarbases200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdStarbases200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdStarbases200Ok>)));
         }
 
@@ -4820,7 +4820,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdStarbases200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdStarbases200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdStarbases200Ok>)));
         }
 
@@ -4914,7 +4914,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdStarbasesStarbaseIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdStarbasesStarbaseIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdStarbasesStarbaseIdOk)));
         }
 
@@ -5009,7 +5009,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdStarbasesStarbaseIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdStarbasesStarbaseIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdStarbasesStarbaseIdOk)));
         }
 
@@ -5100,7 +5100,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdStructures200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdStructures200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdStructures200Ok>)));
         }
 
@@ -5192,7 +5192,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdStructures200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdStructures200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdStructures200Ok>)));
         }
 
@@ -5274,7 +5274,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdTitles200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdTitles200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdTitles200Ok>)));
         }
 
@@ -5357,7 +5357,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdTitles200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdTitles200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdTitles200Ok>)));
         }
 
@@ -5430,7 +5430,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsNames200Ok>)));
         }
 
@@ -5504,7 +5504,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsNames200Ok>)));
         }
 
@@ -5571,7 +5571,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -5639,7 +5639,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/DogmaApi.cs
+++ b/src/ESIClient.Dotcore/Api/DogmaApi.cs
@@ -381,7 +381,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -449,7 +449,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -522,7 +522,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetDogmaAttributesAttributeIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetDogmaAttributesAttributeIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetDogmaAttributesAttributeIdOk)));
         }
 
@@ -596,7 +596,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetDogmaAttributesAttributeIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetDogmaAttributesAttributeIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetDogmaAttributesAttributeIdOk)));
         }
 
@@ -663,7 +663,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -731,7 +731,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -804,7 +804,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetDogmaEffectsEffectIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetDogmaEffectsEffectIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetDogmaEffectsEffectIdOk)));
         }
 
@@ -878,7 +878,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetDogmaEffectsEffectIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetDogmaEffectsEffectIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetDogmaEffectsEffectIdOk)));
         }
 

--- a/src/ESIClient.Dotcore/Api/FactionWarfareApi.cs
+++ b/src/ESIClient.Dotcore/Api/FactionWarfareApi.cs
@@ -588,7 +588,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdFwStatsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdFwStatsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdFwStatsOk)));
         }
 
@@ -671,7 +671,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdFwStatsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdFwStatsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdFwStatsOk)));
         }
 
@@ -753,7 +753,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdFwStatsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdFwStatsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdFwStatsOk)));
         }
 
@@ -836,7 +836,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCorporationsCorporationIdFwStatsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCorporationsCorporationIdFwStatsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCorporationsCorporationIdFwStatsOk)));
         }
 
@@ -903,7 +903,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetFwLeaderboardsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetFwLeaderboardsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetFwLeaderboardsOk)));
         }
 
@@ -971,7 +971,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetFwLeaderboardsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetFwLeaderboardsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetFwLeaderboardsOk)));
         }
 
@@ -1038,7 +1038,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetFwLeaderboardsCharactersOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetFwLeaderboardsCharactersOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetFwLeaderboardsCharactersOk)));
         }
 
@@ -1106,7 +1106,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetFwLeaderboardsCharactersOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetFwLeaderboardsCharactersOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetFwLeaderboardsCharactersOk)));
         }
 
@@ -1173,7 +1173,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetFwLeaderboardsCorporationsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetFwLeaderboardsCorporationsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetFwLeaderboardsCorporationsOk)));
         }
 
@@ -1241,7 +1241,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetFwLeaderboardsCorporationsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetFwLeaderboardsCorporationsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetFwLeaderboardsCorporationsOk)));
         }
 
@@ -1308,7 +1308,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetFwStats200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetFwStats200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetFwStats200Ok>)));
         }
 
@@ -1376,7 +1376,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetFwStats200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetFwStats200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetFwStats200Ok>)));
         }
 
@@ -1443,7 +1443,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetFwSystems200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetFwSystems200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetFwSystems200Ok>)));
         }
 
@@ -1511,7 +1511,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetFwSystems200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetFwSystems200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetFwSystems200Ok>)));
         }
 
@@ -1578,7 +1578,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetFwWars200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetFwWars200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetFwWars200Ok>)));
         }
 
@@ -1646,7 +1646,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetFwWars200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetFwWars200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetFwWars200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/FittingsApi.cs
+++ b/src/ESIClient.Dotcore/Api/FittingsApi.cs
@@ -368,7 +368,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -453,7 +453,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -535,7 +535,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdFittings200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdFittings200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdFittings200Ok>)));
         }
 
@@ -618,7 +618,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdFittings200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdFittings200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdFittings200Ok>)));
         }
 
@@ -710,7 +710,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<PostCharactersCharacterIdFittingsCreated>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (PostCharactersCharacterIdFittingsCreated) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(PostCharactersCharacterIdFittingsCreated)));
         }
 
@@ -803,7 +803,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<PostCharactersCharacterIdFittingsCreated>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (PostCharactersCharacterIdFittingsCreated) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(PostCharactersCharacterIdFittingsCreated)));
         }
 

--- a/src/ESIClient.Dotcore/Api/FleetsApi.cs
+++ b/src/ESIClient.Dotcore/Api/FleetsApi.cs
@@ -986,7 +986,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -1071,7 +1071,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -1155,7 +1155,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -1240,7 +1240,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -1324,7 +1324,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -1409,7 +1409,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -1491,7 +1491,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdFleetOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdFleetOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdFleetOk)));
         }
 
@@ -1574,7 +1574,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdFleetOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdFleetOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdFleetOk)));
         }
 
@@ -1656,7 +1656,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetFleetsFleetIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetFleetsFleetIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetFleetsFleetIdOk)));
         }
 
@@ -1739,7 +1739,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetFleetsFleetIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetFleetsFleetIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetFleetsFleetIdOk)));
         }
 
@@ -1827,7 +1827,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetFleetsFleetIdMembers200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetFleetsFleetIdMembers200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetFleetsFleetIdMembers200Ok>)));
         }
 
@@ -1916,7 +1916,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetFleetsFleetIdMembers200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetFleetsFleetIdMembers200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetFleetsFleetIdMembers200Ok>)));
         }
 
@@ -2004,7 +2004,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetFleetsFleetIdWings200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetFleetsFleetIdWings200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetFleetsFleetIdWings200Ok>)));
         }
 
@@ -2093,7 +2093,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetFleetsFleetIdWings200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetFleetsFleetIdWings200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetFleetsFleetIdWings200Ok>)));
         }
 
@@ -2184,7 +2184,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -2276,7 +2276,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -2355,7 +2355,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<PostFleetsFleetIdWingsCreated>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (PostFleetsFleetIdWingsCreated) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(PostFleetsFleetIdWingsCreated)));
         }
 
@@ -2435,7 +2435,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<PostFleetsFleetIdWingsCreated>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (PostFleetsFleetIdWingsCreated) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(PostFleetsFleetIdWingsCreated)));
         }
 
@@ -2520,7 +2520,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<PostFleetsFleetIdWingsWingIdSquadsCreated>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (PostFleetsFleetIdWingsWingIdSquadsCreated) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(PostFleetsFleetIdWingsWingIdSquadsCreated)));
         }
 
@@ -2606,7 +2606,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<PostFleetsFleetIdWingsWingIdSquadsCreated>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (PostFleetsFleetIdWingsWingIdSquadsCreated) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(PostFleetsFleetIdWingsWingIdSquadsCreated)));
         }
 
@@ -2697,7 +2697,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -2789,7 +2789,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -2886,7 +2886,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -2984,7 +2984,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -3081,7 +3081,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -3179,7 +3179,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -3276,7 +3276,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -3374,7 +3374,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 

--- a/src/ESIClient.Dotcore/Api/IncursionsApi.cs
+++ b/src/ESIClient.Dotcore/Api/IncursionsApi.cs
@@ -235,7 +235,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetIncursions200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetIncursions200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetIncursions200Ok>)));
         }
 
@@ -303,7 +303,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetIncursions200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetIncursions200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetIncursions200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/IndustryApi.cs
+++ b/src/ESIClient.Dotcore/Api/IndustryApi.cs
@@ -655,7 +655,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdIndustryJobs200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdIndustryJobs200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdIndustryJobs200Ok>)));
         }
 
@@ -741,7 +741,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdIndustryJobs200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdIndustryJobs200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdIndustryJobs200Ok>)));
         }
 
@@ -826,7 +826,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdMining200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdMining200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdMining200Ok>)));
         }
 
@@ -912,7 +912,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdMining200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdMining200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdMining200Ok>)));
         }
 
@@ -997,7 +997,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationCorporationIdMiningExtractions200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationCorporationIdMiningExtractions200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationCorporationIdMiningExtractions200Ok>)));
         }
 
@@ -1083,7 +1083,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationCorporationIdMiningExtractions200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationCorporationIdMiningExtractions200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationCorporationIdMiningExtractions200Ok>)));
         }
 
@@ -1168,7 +1168,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationCorporationIdMiningObservers200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationCorporationIdMiningObservers200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationCorporationIdMiningObservers200Ok>)));
         }
 
@@ -1254,7 +1254,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationCorporationIdMiningObservers200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationCorporationIdMiningObservers200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationCorporationIdMiningObservers200Ok>)));
         }
 
@@ -1345,7 +1345,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationCorporationIdMiningObserversObserverId200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationCorporationIdMiningObserversObserverId200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationCorporationIdMiningObserversObserverId200Ok>)));
         }
 
@@ -1437,7 +1437,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationCorporationIdMiningObserversObserverId200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationCorporationIdMiningObserversObserverId200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationCorporationIdMiningObserversObserverId200Ok>)));
         }
 
@@ -1525,7 +1525,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdIndustryJobs200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdIndustryJobs200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdIndustryJobs200Ok>)));
         }
 
@@ -1614,7 +1614,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdIndustryJobs200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdIndustryJobs200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdIndustryJobs200Ok>)));
         }
 
@@ -1681,7 +1681,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetIndustryFacilities200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetIndustryFacilities200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetIndustryFacilities200Ok>)));
         }
 
@@ -1749,7 +1749,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetIndustryFacilities200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetIndustryFacilities200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetIndustryFacilities200Ok>)));
         }
 
@@ -1816,7 +1816,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetIndustrySystems200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetIndustrySystems200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetIndustrySystems200Ok>)));
         }
 
@@ -1884,7 +1884,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetIndustrySystems200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetIndustrySystems200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetIndustrySystems200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/InsuranceApi.cs
+++ b/src/ESIClient.Dotcore/Api/InsuranceApi.cs
@@ -249,7 +249,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetInsurancePrices200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetInsurancePrices200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetInsurancePrices200Ok>)));
         }
 
@@ -323,7 +323,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetInsurancePrices200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetInsurancePrices200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetInsurancePrices200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/KillmailsApi.cs
+++ b/src/ESIClient.Dotcore/Api/KillmailsApi.cs
@@ -377,7 +377,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdKillmailsRecent200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdKillmailsRecent200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdKillmailsRecent200Ok>)));
         }
 
@@ -463,7 +463,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdKillmailsRecent200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdKillmailsRecent200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdKillmailsRecent200Ok>)));
         }
 
@@ -548,7 +548,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdKillmailsRecent200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdKillmailsRecent200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdKillmailsRecent200Ok>)));
         }
 
@@ -634,7 +634,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdKillmailsRecent200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdKillmailsRecent200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdKillmailsRecent200Ok>)));
         }
 
@@ -713,7 +713,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetKillmailsKillmailIdKillmailHashOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetKillmailsKillmailIdKillmailHashOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetKillmailsKillmailIdKillmailHashOk)));
         }
 
@@ -793,7 +793,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetKillmailsKillmailIdKillmailHashOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetKillmailsKillmailIdKillmailHashOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetKillmailsKillmailIdKillmailHashOk)));
         }
 

--- a/src/ESIClient.Dotcore/Api/LocationApi.cs
+++ b/src/ESIClient.Dotcore/Api/LocationApi.cs
@@ -366,7 +366,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdLocationOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdLocationOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdLocationOk)));
         }
 
@@ -449,7 +449,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdLocationOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdLocationOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdLocationOk)));
         }
 
@@ -531,7 +531,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdOnlineOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdOnlineOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdOnlineOk)));
         }
 
@@ -614,7 +614,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdOnlineOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdOnlineOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdOnlineOk)));
         }
 
@@ -696,7 +696,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdShipOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdShipOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdShipOk)));
         }
 
@@ -779,7 +779,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdShipOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdShipOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdShipOk)));
         }
 

--- a/src/ESIClient.Dotcore/Api/LoyaltyApi.cs
+++ b/src/ESIClient.Dotcore/Api/LoyaltyApi.cs
@@ -308,7 +308,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdLoyaltyPoints200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdLoyaltyPoints200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdLoyaltyPoints200Ok>)));
         }
 
@@ -391,7 +391,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdLoyaltyPoints200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdLoyaltyPoints200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdLoyaltyPoints200Ok>)));
         }
 
@@ -464,7 +464,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetLoyaltyStoresCorporationIdOffers200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetLoyaltyStoresCorporationIdOffers200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetLoyaltyStoresCorporationIdOffers200Ok>)));
         }
 
@@ -538,7 +538,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetLoyaltyStoresCorporationIdOffers200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetLoyaltyStoresCorporationIdOffers200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetLoyaltyStoresCorporationIdOffers200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/MailApi.cs
+++ b/src/ESIClient.Dotcore/Api/MailApi.cs
@@ -708,7 +708,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -793,7 +793,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -877,7 +877,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -962,7 +962,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -1050,7 +1050,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdMail200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdMail200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdMail200Ok>)));
         }
 
@@ -1139,7 +1139,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdMail200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdMail200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdMail200Ok>)));
         }
 
@@ -1221,7 +1221,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdMailLabelsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdMailLabelsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdMailLabelsOk)));
         }
 
@@ -1304,7 +1304,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdMailLabelsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdMailLabelsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdMailLabelsOk)));
         }
 
@@ -1386,7 +1386,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdMailLists200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdMailLists200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdMailLists200Ok>)));
         }
 
@@ -1469,7 +1469,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdMailLists200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdMailLists200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdMailLists200Ok>)));
         }
 
@@ -1557,7 +1557,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdMailMailIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdMailMailIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdMailMailIdOk)));
         }
 
@@ -1646,7 +1646,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdMailMailIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdMailMailIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdMailMailIdOk)));
         }
 
@@ -1738,7 +1738,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<int?>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (int?) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(int?)));
         }
 
@@ -1831,7 +1831,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<int?>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (int?) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(int?)));
         }
 
@@ -1923,7 +1923,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<int?>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (int?) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(int?)));
         }
 
@@ -2016,7 +2016,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<int?>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (int?) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(int?)));
         }
 
@@ -2113,7 +2113,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -2211,7 +2211,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 

--- a/src/ESIClient.Dotcore/Api/MarketApi.cs
+++ b/src/ESIClient.Dotcore/Api/MarketApi.cs
@@ -810,7 +810,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdOrders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdOrders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdOrders200Ok>)));
         }
 
@@ -893,7 +893,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdOrders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdOrders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdOrders200Ok>)));
         }
 
@@ -978,7 +978,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdOrdersHistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdOrdersHistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdOrdersHistory200Ok>)));
         }
 
@@ -1064,7 +1064,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdOrdersHistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdOrdersHistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdOrdersHistory200Ok>)));
         }
 
@@ -1149,7 +1149,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdOrders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdOrders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdOrders200Ok>)));
         }
 
@@ -1235,7 +1235,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdOrders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdOrders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdOrders200Ok>)));
         }
 
@@ -1320,7 +1320,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdOrdersHistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdOrdersHistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdOrdersHistory200Ok>)));
         }
 
@@ -1406,7 +1406,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdOrdersHistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdOrdersHistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdOrdersHistory200Ok>)));
         }
 
@@ -1473,7 +1473,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -1541,7 +1541,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -1620,7 +1620,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetMarketsGroupsMarketGroupIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetMarketsGroupsMarketGroupIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetMarketsGroupsMarketGroupIdOk)));
         }
 
@@ -1700,7 +1700,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetMarketsGroupsMarketGroupIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetMarketsGroupsMarketGroupIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetMarketsGroupsMarketGroupIdOk)));
         }
 
@@ -1767,7 +1767,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetMarketsPrices200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetMarketsPrices200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetMarketsPrices200Ok>)));
         }
 
@@ -1835,7 +1835,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetMarketsPrices200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetMarketsPrices200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetMarketsPrices200Ok>)));
         }
 
@@ -1914,7 +1914,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetMarketsRegionIdHistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetMarketsRegionIdHistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetMarketsRegionIdHistory200Ok>)));
         }
 
@@ -1994,7 +1994,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetMarketsRegionIdHistory200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetMarketsRegionIdHistory200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetMarketsRegionIdHistory200Ok>)));
         }
 
@@ -2079,7 +2079,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetMarketsRegionIdOrders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetMarketsRegionIdOrders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetMarketsRegionIdOrders200Ok>)));
         }
 
@@ -2165,7 +2165,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetMarketsRegionIdOrders200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetMarketsRegionIdOrders200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetMarketsRegionIdOrders200Ok>)));
         }
 
@@ -2241,7 +2241,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -2318,7 +2318,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -2403,7 +2403,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetMarketsStructuresStructureId200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetMarketsStructuresStructureId200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetMarketsStructuresStructureId200Ok>)));
         }
 
@@ -2489,7 +2489,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetMarketsStructuresStructureId200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetMarketsStructuresStructureId200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetMarketsStructuresStructureId200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/OpportunitiesApi.cs
+++ b/src/ESIClient.Dotcore/Api/OpportunitiesApi.cs
@@ -458,7 +458,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdOpportunities200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdOpportunities200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdOpportunities200Ok>)));
         }
 
@@ -541,7 +541,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdOpportunities200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdOpportunities200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdOpportunities200Ok>)));
         }
 
@@ -608,7 +608,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -676,7 +676,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -755,7 +755,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetOpportunitiesGroupsGroupIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetOpportunitiesGroupsGroupIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetOpportunitiesGroupsGroupIdOk)));
         }
 
@@ -835,7 +835,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetOpportunitiesGroupsGroupIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetOpportunitiesGroupsGroupIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetOpportunitiesGroupsGroupIdOk)));
         }
 
@@ -902,7 +902,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -970,7 +970,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -1043,7 +1043,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetOpportunitiesTasksTaskIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetOpportunitiesTasksTaskIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetOpportunitiesTasksTaskIdOk)));
         }
 
@@ -1117,7 +1117,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetOpportunitiesTasksTaskIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetOpportunitiesTasksTaskIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetOpportunitiesTasksTaskIdOk)));
         }
 

--- a/src/ESIClient.Dotcore/Api/PlanetaryInteractionApi.cs
+++ b/src/ESIClient.Dotcore/Api/PlanetaryInteractionApi.cs
@@ -424,7 +424,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdPlanets200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdPlanets200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdPlanets200Ok>)));
         }
 
@@ -507,7 +507,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdPlanets200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdPlanets200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdPlanets200Ok>)));
         }
 
@@ -595,7 +595,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdPlanetsPlanetIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdPlanetsPlanetIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdPlanetsPlanetIdOk)));
         }
 
@@ -684,7 +684,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdPlanetsPlanetIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdPlanetsPlanetIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdPlanetsPlanetIdOk)));
         }
 
@@ -769,7 +769,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdCustomsOffices200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdCustomsOffices200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdCustomsOffices200Ok>)));
         }
 
@@ -855,7 +855,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdCustomsOffices200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdCustomsOffices200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdCustomsOffices200Ok>)));
         }
 
@@ -928,7 +928,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseSchematicsSchematicIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseSchematicsSchematicIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseSchematicsSchematicIdOk)));
         }
 
@@ -1002,7 +1002,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseSchematicsSchematicIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseSchematicsSchematicIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseSchematicsSchematicIdOk)));
         }
 

--- a/src/ESIClient.Dotcore/Api/RoutesApi.cs
+++ b/src/ESIClient.Dotcore/Api/RoutesApi.cs
@@ -276,7 +276,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -365,7 +365,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/SearchApi.cs
+++ b/src/ESIClient.Dotcore/Api/SearchApi.cs
@@ -365,7 +365,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdSearchOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdSearchOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdSearchOk)));
         }
 
@@ -469,7 +469,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdSearchOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdSearchOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdSearchOk)));
         }
 
@@ -557,7 +557,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetSearchOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetSearchOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetSearchOk)));
         }
 
@@ -646,7 +646,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetSearchOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetSearchOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetSearchOk)));
         }
 

--- a/src/ESIClient.Dotcore/Api/SkillsApi.cs
+++ b/src/ESIClient.Dotcore/Api/SkillsApi.cs
@@ -366,7 +366,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdAttributesOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdAttributesOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdAttributesOk)));
         }
 
@@ -449,7 +449,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdAttributesOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdAttributesOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdAttributesOk)));
         }
 
@@ -531,7 +531,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdSkillqueue200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdSkillqueue200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdSkillqueue200Ok>)));
         }
 
@@ -614,7 +614,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdSkillqueue200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdSkillqueue200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdSkillqueue200Ok>)));
         }
 
@@ -696,7 +696,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdSkillsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdSkillsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdSkillsOk)));
         }
 
@@ -779,7 +779,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetCharactersCharacterIdSkillsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetCharactersCharacterIdSkillsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetCharactersCharacterIdSkillsOk)));
         }
 

--- a/src/ESIClient.Dotcore/Api/SovereigntyApi.cs
+++ b/src/ESIClient.Dotcore/Api/SovereigntyApi.cs
@@ -327,7 +327,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetSovereigntyCampaigns200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetSovereigntyCampaigns200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetSovereigntyCampaigns200Ok>)));
         }
 
@@ -395,7 +395,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetSovereigntyCampaigns200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetSovereigntyCampaigns200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetSovereigntyCampaigns200Ok>)));
         }
 
@@ -462,7 +462,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetSovereigntyMap200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetSovereigntyMap200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetSovereigntyMap200Ok>)));
         }
 
@@ -530,7 +530,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetSovereigntyMap200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetSovereigntyMap200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetSovereigntyMap200Ok>)));
         }
 
@@ -597,7 +597,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetSovereigntyStructures200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetSovereigntyStructures200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetSovereigntyStructures200Ok>)));
         }
 
@@ -665,7 +665,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetSovereigntyStructures200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetSovereigntyStructures200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetSovereigntyStructures200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/StatusApi.cs
+++ b/src/ESIClient.Dotcore/Api/StatusApi.cs
@@ -235,7 +235,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetStatusOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetStatusOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetStatusOk)));
         }
 
@@ -303,7 +303,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetStatusOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetStatusOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetStatusOk)));
         }
 

--- a/src/ESIClient.Dotcore/Api/UniverseApi.cs
+++ b/src/ESIClient.Dotcore/Api/UniverseApi.cs
@@ -1731,7 +1731,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseAncestries200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseAncestries200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseAncestries200Ok>)));
         }
 
@@ -1805,7 +1805,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseAncestries200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseAncestries200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseAncestries200Ok>)));
         }
 
@@ -1878,7 +1878,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseAsteroidBeltsAsteroidBeltIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseAsteroidBeltsAsteroidBeltIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseAsteroidBeltsAsteroidBeltIdOk)));
         }
 
@@ -1952,7 +1952,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseAsteroidBeltsAsteroidBeltIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseAsteroidBeltsAsteroidBeltIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseAsteroidBeltsAsteroidBeltIdOk)));
         }
 
@@ -2025,7 +2025,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseBloodlines200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseBloodlines200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseBloodlines200Ok>)));
         }
 
@@ -2099,7 +2099,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseBloodlines200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseBloodlines200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseBloodlines200Ok>)));
         }
 
@@ -2166,7 +2166,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -2234,7 +2234,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -2313,7 +2313,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseCategoriesCategoryIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseCategoriesCategoryIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseCategoriesCategoryIdOk)));
         }
 
@@ -2393,7 +2393,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseCategoriesCategoryIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseCategoriesCategoryIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseCategoriesCategoryIdOk)));
         }
 
@@ -2460,7 +2460,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -2528,7 +2528,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -2607,7 +2607,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseConstellationsConstellationIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseConstellationsConstellationIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseConstellationsConstellationIdOk)));
         }
 
@@ -2687,7 +2687,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseConstellationsConstellationIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseConstellationsConstellationIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseConstellationsConstellationIdOk)));
         }
 
@@ -2760,7 +2760,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseFactions200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseFactions200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseFactions200Ok>)));
         }
 
@@ -2834,7 +2834,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseFactions200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseFactions200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseFactions200Ok>)));
         }
 
@@ -2901,7 +2901,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -2969,7 +2969,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -3042,7 +3042,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseGraphicsGraphicIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseGraphicsGraphicIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseGraphicsGraphicIdOk)));
         }
 
@@ -3116,7 +3116,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseGraphicsGraphicIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseGraphicsGraphicIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseGraphicsGraphicIdOk)));
         }
 
@@ -3186,7 +3186,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -3257,7 +3257,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -3336,7 +3336,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseGroupsGroupIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseGroupsGroupIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseGroupsGroupIdOk)));
         }
 
@@ -3416,7 +3416,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseGroupsGroupIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseGroupsGroupIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseGroupsGroupIdOk)));
         }
 
@@ -3489,7 +3489,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseMoonsMoonIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseMoonsMoonIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseMoonsMoonIdOk)));
         }
 
@@ -3563,7 +3563,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseMoonsMoonIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseMoonsMoonIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseMoonsMoonIdOk)));
         }
 
@@ -3636,7 +3636,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniversePlanetsPlanetIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniversePlanetsPlanetIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniversePlanetsPlanetIdOk)));
         }
 
@@ -3710,7 +3710,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniversePlanetsPlanetIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniversePlanetsPlanetIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniversePlanetsPlanetIdOk)));
         }
 
@@ -3783,7 +3783,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseRaces200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseRaces200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseRaces200Ok>)));
         }
 
@@ -3857,7 +3857,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseRaces200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseRaces200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseRaces200Ok>)));
         }
 
@@ -3924,7 +3924,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -3992,7 +3992,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -4071,7 +4071,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseRegionsRegionIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseRegionsRegionIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseRegionsRegionIdOk)));
         }
 
@@ -4151,7 +4151,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseRegionsRegionIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseRegionsRegionIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseRegionsRegionIdOk)));
         }
 
@@ -4224,7 +4224,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseStargatesStargateIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseStargatesStargateIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseStargatesStargateIdOk)));
         }
 
@@ -4298,7 +4298,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseStargatesStargateIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseStargatesStargateIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseStargatesStargateIdOk)));
         }
 
@@ -4371,7 +4371,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseStarsStarIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseStarsStarIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseStarsStarIdOk)));
         }
 
@@ -4445,7 +4445,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseStarsStarIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseStarsStarIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseStarsStarIdOk)));
         }
 
@@ -4518,7 +4518,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseStationsStationIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseStationsStationIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseStationsStationIdOk)));
         }
 
@@ -4592,7 +4592,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseStationsStationIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseStationsStationIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseStationsStationIdOk)));
         }
 
@@ -4659,7 +4659,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<long?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<long?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<long?>)));
         }
 
@@ -4727,7 +4727,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<long?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<long?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<long?>)));
         }
 
@@ -4809,7 +4809,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseStructuresStructureIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseStructuresStructureIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseStructuresStructureIdOk)));
         }
 
@@ -4892,7 +4892,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseStructuresStructureIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseStructuresStructureIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseStructuresStructureIdOk)));
         }
 
@@ -4959,7 +4959,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseSystemJumps200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseSystemJumps200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseSystemJumps200Ok>)));
         }
 
@@ -5027,7 +5027,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseSystemJumps200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseSystemJumps200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseSystemJumps200Ok>)));
         }
 
@@ -5094,7 +5094,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseSystemKills200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseSystemKills200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseSystemKills200Ok>)));
         }
 
@@ -5162,7 +5162,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetUniverseSystemKills200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetUniverseSystemKills200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetUniverseSystemKills200Ok>)));
         }
 
@@ -5229,7 +5229,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -5297,7 +5297,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -5376,7 +5376,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseSystemsSystemIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseSystemsSystemIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseSystemsSystemIdOk)));
         }
 
@@ -5456,7 +5456,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseSystemsSystemIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseSystemsSystemIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseSystemsSystemIdOk)));
         }
 
@@ -5526,7 +5526,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -5597,7 +5597,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -5676,7 +5676,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseTypesTypeIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseTypesTypeIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseTypesTypeIdOk)));
         }
 
@@ -5756,7 +5756,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetUniverseTypesTypeIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetUniverseTypesTypeIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetUniverseTypesTypeIdOk)));
         }
 
@@ -5839,7 +5839,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<PostUniverseIdsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (PostUniverseIdsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(PostUniverseIdsOk)));
         }
 
@@ -5923,7 +5923,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<PostUniverseIdsOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (PostUniverseIdsOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(PostUniverseIdsOk)));
         }
 
@@ -6000,7 +6000,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostUniverseNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostUniverseNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostUniverseNames200Ok>)));
         }
 
@@ -6078,7 +6078,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<PostUniverseNames200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<PostUniverseNames200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<PostUniverseNames200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/UserInterfaceApi.cs
+++ b/src/ESIClient.Dotcore/Api/UserInterfaceApi.cs
@@ -470,7 +470,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -561,7 +561,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -639,7 +639,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -718,7 +718,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -796,7 +796,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -875,7 +875,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -953,7 +953,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -1032,7 +1032,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -1117,7 +1117,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 
@@ -1203,7 +1203,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<Object>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 null);
         }
 

--- a/src/ESIClient.Dotcore/Api/WalletApi.cs
+++ b/src/ESIClient.Dotcore/Api/WalletApi.cs
@@ -552,7 +552,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<double?>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (double?) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(double?)));
         }
 
@@ -635,7 +635,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<double?>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (double?) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(double?)));
         }
 
@@ -720,7 +720,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdWalletJournal200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdWalletJournal200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdWalletJournal200Ok>)));
         }
 
@@ -806,7 +806,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdWalletJournal200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdWalletJournal200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdWalletJournal200Ok>)));
         }
 
@@ -891,7 +891,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdWalletTransactions200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdWalletTransactions200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdWalletTransactions200Ok>)));
         }
 
@@ -977,7 +977,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCharactersCharacterIdWalletTransactions200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCharactersCharacterIdWalletTransactions200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCharactersCharacterIdWalletTransactions200Ok>)));
         }
 
@@ -1059,7 +1059,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdWallets200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdWallets200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdWallets200Ok>)));
         }
 
@@ -1142,7 +1142,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdWallets200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdWallets200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdWallets200Ok>)));
         }
 
@@ -1233,7 +1233,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdWalletsDivisionJournal200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdWalletsDivisionJournal200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdWalletsDivisionJournal200Ok>)));
         }
 
@@ -1325,7 +1325,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdWalletsDivisionJournal200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdWalletsDivisionJournal200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdWalletsDivisionJournal200Ok>)));
         }
 
@@ -1416,7 +1416,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdWalletsDivisionTransactions200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdWalletsDivisionTransactions200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdWalletsDivisionTransactions200Ok>)));
         }
 
@@ -1508,7 +1508,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetCorporationsCorporationIdWalletsDivisionTransactions200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetCorporationsCorporationIdWalletsDivisionTransactions200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetCorporationsCorporationIdWalletsDivisionTransactions200Ok>)));
         }
 

--- a/src/ESIClient.Dotcore/Api/WarsApi.cs
+++ b/src/ESIClient.Dotcore/Api/WarsApi.cs
@@ -346,7 +346,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -417,7 +417,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<int?>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<int?>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<int?>)));
         }
 
@@ -490,7 +490,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetWarsWarIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetWarsWarIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetWarsWarIdOk)));
         }
 
@@ -564,7 +564,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<GetWarsWarIdOk>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (GetWarsWarIdOk) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(GetWarsWarIdOk)));
         }
 
@@ -640,7 +640,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetWarsWarIdKillmails200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetWarsWarIdKillmails200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetWarsWarIdKillmails200Ok>)));
         }
 
@@ -717,7 +717,7 @@ namespace ESIClient.Dotcore.Api
             }
 
             return new ApiResponse<List<GetWarsWarIdKillmails200Ok>>(localVarStatusCode,
-                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault().ToString()),
                 (List<GetWarsWarIdKillmails200Ok>) this.Configuration.ApiClient.Deserialize(localVarResponse, typeof(List<GetWarsWarIdKillmails200Ok>)));
         }
 


### PR DESCRIPTION
calling FirstOrDefault solves the problem of type names as a string #1 